### PR TITLE
feat(gui,qblade): simplify geometry workflow and QBlade integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/sandialabs/VorLap/actions/workflows/tests.yml/badge.svg)](https://github.com/sandialabs/VorLap/actions/workflows/tests.yml)
 [![Docs](https://github.com/sandialabs/VorLap/actions/workflows/docs.yml/badge.svg)](https://github.com/sandialabs/VorLap/actions/workflows/docs.yml)
 [![GUI Builds](https://github.com/sandialabs/VorLap/actions/workflows/build_gui.yml/badge.svg)](https://github.com/sandialabs/VorLap/actions/workflows/build_gui.yml)
+[![Dev Builds (main)](https://img.shields.io/badge/dev_builds-main-blue)](https://github.com/sandialabs/VorLap/actions/workflows/build_gui.yml?query=branch%3Amain)
 [![Download](https://img.shields.io/github/v/release/sandialabs/VorLap?label=download)](https://github.com/sandialabs/VorLap/releases/latest)
 
 VorLap (Vortex overLAP) predicts aerodynamic force spectra, force reconstruction, and frequency overlap risk for rotating structures using FFT-based airfoil databases.
@@ -69,7 +70,15 @@ mkdocs build --strict
 Launch GUI:
 
 ```bash
-python scripts/launch_gui.py
+python3 scripts/launch_gui.py
+```
+
+If zsh reports `unknown file attribute: b`, your `python` shell alias/function is interfering with glob parsing. Use:
+
+```bash
+python3 scripts/launch_gui.py
+# or explicitly:
+.venv/bin/python scripts/launch_gui.py
 ```
 
 Run a scripted time-varying inflow example:

--- a/data/components/componentsSingle/tower.csv
+++ b/data/components/componentsSingle/tower.csv
@@ -1,0 +1,5 @@
+id,translation_x,translation_y,translation_z,rotation_x,rotation_y,rotation_z,pitch
+Tower,0,0,0,0,0,0,0
+x,y,z,chord,twist,thickness,offset,airfoil_id
+0,0,0,1,0,0.18,0.5,NACA0018
+0,0,80,1,0,0.18,0.5,NACA0018

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -106,6 +106,16 @@ def test_compute_spectrum_missing_default_airfoil_raises():
         compute_thrust_torque_spectrum_optimized([component], affts, viv_params, np.array([1.0]))
 
 
+def test_compute_spectrum_missing_airfoil_warns_and_falls_back_to_default():
+    component = make_component(n_nodes=2, span=2.0, airfoil_id="cylinder")
+    default_afft = make_constant_airfoil_fft(name="NACA0018")
+    affts = {"default": default_afft}
+    viv_params = make_viv_params()
+
+    with pytest.warns(RuntimeWarning, match="using default airfoil 'NACA0018'"):
+        compute_thrust_torque_spectrum_optimized([component], affts, viv_params, np.array([1.0]))
+
+
 def test_time_varying_force_history_matches_single_case_reconstruction():
     component = make_component(n_nodes=2, span=2.0, airfoil_id="default")
     afft = make_constant_airfoil_fft(n_freq=2)

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -14,6 +14,7 @@ from vorlap.fileio import (
     load_qblade_blade_definition,
     load_qblade_simulation_definition,
     load_qblade_turbine_definition,
+    write_components_to_csv,
     write_force_time_series,
     write_qblade_loading_file,
 )
@@ -49,6 +50,28 @@ def test_load_components_from_csv_parses_component(tmp_path: Path):
     np.testing.assert_allclose(comp.translation, np.array([1.0, 2.0, 3.0]))
     np.testing.assert_allclose(comp.rotation, np.array([4.0, 5.0, 6.0]))
     assert comp.airfoil_ids == ["default"]
+
+
+def test_write_components_to_csv_roundtrip(tmp_path: Path):
+    comp_dir = tmp_path / "components_in"
+    comp_dir.mkdir()
+    _write_component_csv(comp_dir / "blade.csv")
+    components = load_components_from_csv(str(comp_dir))
+
+    out_dir = tmp_path / "components_out"
+    written = write_components_to_csv(str(out_dir), components)
+
+    assert len(written) == 1
+    assert Path(written[0]).exists()
+
+    reloaded = load_components_from_csv(str(out_dir))
+    assert len(reloaded) == 1
+    np.testing.assert_allclose(reloaded[0].shape_xyz, components[0].shape_xyz)
+    np.testing.assert_allclose(reloaded[0].chord, components[0].chord)
+    np.testing.assert_allclose(reloaded[0].twist, components[0].twist)
+    np.testing.assert_allclose(reloaded[0].thickness, components[0].thickness)
+    np.testing.assert_allclose(reloaded[0].offset, components[0].offset)
+    assert reloaded[0].airfoil_ids == components[0].airfoil_ids
 
 
 def test_load_components_from_csv_missing_required_column_raises(tmp_path: Path):
@@ -269,6 +292,18 @@ def test_convert_qblade_to_vorlap_inputs(tmp_path: Path):
     assert viv_params.fluid_density == pytest.approx(1.30)
     assert viv_params.fluid_dynamicviscosity == pytest.approx(1.3e-5)
     np.testing.assert_allclose(viv_params.rotation_axis_offset, np.array([1.0, 2.0, 3.0]))
+
+
+def test_convert_qblade_to_vorlap_inputs_tower_defaults_to_cylinder(tmp_path: Path):
+    sim, trb, _bld = _write_qblade_minimal_files(tmp_path)
+    with trb.open("a") as f:
+        f.write("12.0 TOWERHEIGHT - tower height\n")
+        f.write("0.50 TOWERTOPRAD - tower top radius\n")
+        f.write("0.70 TOWERBOTRAD - tower bottom radius\n")
+
+    components, _viv_params, _node_ids = convert_qblade_to_vorlap_inputs(str(sim), include_tower=True)
+    tower = next(comp for comp in components if comp.id == "TWR_1")
+    assert set(tower.airfoil_ids) == {"cylinder"}
 
 
 def test_write_qblade_loading_file(tmp_path: Path):

--- a/vorlap/__init__.py
+++ b/vorlap/__init__.py
@@ -23,6 +23,7 @@ from .fileio import (
     load_qblade_simulation_definition,
     load_qblade_turbine_definition,
     load_inflow_time_series,
+    write_components_to_csv,
     write_qblade_loading_file,
     write_force_time_series
 )
@@ -67,6 +68,7 @@ __all__ = [
     "resample_airfoil",
     "rotate_vector",
     "rotationMatrix",
+    "write_components_to_csv",
     "write_qblade_loading_file",
     "write_force_time_series",
 ]

--- a/vorlap/computations.py
+++ b/vorlap/computations.py
@@ -22,11 +22,29 @@ def _normalize(vector: np.ndarray, name: str) -> np.ndarray:
     return vec / norm
 
 
-def _resolve_airfoil(affts: Dict[str, AirfoilFFT], airfoil_id: str) -> AirfoilFFT:
+def _resolve_airfoil(
+    affts: Dict[str, AirfoilFFT],
+    airfoil_id: str,
+    warned_missing_airfoils: Optional[set] = None,
+) -> AirfoilFFT:
     """Resolve an airfoil id with fallback to `default`."""
     if airfoil_id in affts:
         return affts[airfoil_id]
     if "default" in affts:
+        warn_once = warned_missing_airfoils is not None
+        should_warn = True
+        if warn_once:
+            if airfoil_id in warned_missing_airfoils:
+                should_warn = False
+            else:
+                warned_missing_airfoils.add(airfoil_id)
+        if should_warn:
+            default_name = getattr(affts["default"], "name", "default")
+            warnings.warn(
+                f"Airfoil '{airfoil_id}' not found; using default airfoil '{default_name}'.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         return affts["default"]
     raise KeyError(f"Airfoil '{airfoil_id}' was not found and no 'default' airfoil is available.")
 
@@ -93,6 +111,7 @@ def _compute_thrust_torque_spectrum_impl(
 
     output_azimuth = float(viv_params.output_azimuth_vinf[0])
     output_inflow = float(viv_params.output_azimuth_vinf[1])
+    warned_missing_airfoils: set = set()
 
     for i_inflow, inflow_speed in enumerate(inflow_speeds):
         Vinf = inflow_unit * inflow_speed
@@ -111,7 +130,11 @@ def _compute_thrust_torque_spectrum_impl(
                     global_pos = np.asarray(comp.shape_xyz_global[ipt], dtype=float)
                     chord = float(comp.chord[ipt])
 
-                    afft = _resolve_airfoil(affts, comp.airfoil_ids[ipt])
+                    afft = _resolve_airfoil(
+                        affts,
+                        comp.airfoil_ids[ipt],
+                        warned_missing_airfoils=warned_missing_airfoils,
+                    )
 
                     chord_vector = np.asarray(comp.chord_vector[ipt, :], dtype=float)
                     normal_vector = np.asarray(comp.normal_vector[ipt, :], dtype=float)
@@ -425,13 +448,18 @@ def _compute_time_varying_force_history_impl(
     )
 
     inode = 0
+    warned_missing_airfoils: set = set()
     for comp in components:
         n_pts = comp.shape_xyz.shape[0]
 
         for ipt in range(n_pts):
             global_pos = np.asarray(comp.shape_xyz_global[ipt], dtype=float)
             chord = float(comp.chord[ipt])
-            afft = _resolve_airfoil(affts, comp.airfoil_ids[ipt])
+            afft = _resolve_airfoil(
+                affts,
+                comp.airfoil_ids[ipt],
+                warned_missing_airfoils=warned_missing_airfoils,
+            )
 
             chord_vector = np.asarray(comp.chord_vector[ipt, :], dtype=float)
             normal_vector = np.asarray(comp.normal_vector[ipt, :], dtype=float)
@@ -656,13 +684,13 @@ def reconstruct_signal(freqs: np.ndarray,
     - Negative frequencies, if present, are ignored (assumed redundant w.r.t. positive freqs + phases).
 
     Args:
-        freqs  : array of frequencies [Hz]
-        amps   : array of peak amplitudes corresponding to each frequency
-        phases : array of phase offsets [rad] corresponding to each frequency
-        tvec   : time vector [s] (must have at least 2 samples)
+        freqs (np.ndarray): Array of frequencies [Hz].
+        amps (np.ndarray): Array of peak amplitudes corresponding to each frequency.
+        phases (np.ndarray): Array of phase offsets [rad] corresponding to each frequency.
+        tvec (np.ndarray): Time vector [s] (must have at least 2 samples).
 
     Returns:
-        signal : reconstructed time-domain signal (float64), shape = (len(tvec),)
+        np.ndarray: Reconstructed time-domain signal (float64), shape `(len(tvec),)`.
     """
     freqs  = np.asarray(freqs, dtype=np.float64)
     amps   = np.asarray(amps, dtype=np.float64)

--- a/vorlap/fileio.py
+++ b/vorlap/fileio.py
@@ -3,6 +3,7 @@ File input/output operations for the VorLap package.
 """
 
 import os
+import csv
 import numpy as np
 import pandas as pd
 import h5py
@@ -236,6 +237,8 @@ def convert_qblade_to_vorlap_inputs(
     sim_path: str,
     default_airfoil_id: str = "default",
     include_struts: bool = True,
+    include_tower: bool = True,
+    tower_airfoil_id: str = "cylinder",
 ) -> Tuple[List[Component], VIV_Params, List[str]]:
     """
     Convert a QBlade `.sim` setup into equivalent VorLap components and baseline parameters.
@@ -247,6 +250,10 @@ def convert_qblade_to_vorlap_inputs(
         components: VorLap components equivalent to QBlade blade/strut geometry.
         viv_params: Baseline parameters inferred from QBlade simulation/turbine files.
         qblade_node_ids: Per-node QBlade location IDs aligned with VorLap node ordering.
+
+    Args:
+        include_struts: Include strut components when available in the blade definition.
+        include_tower: Include a tower component inferred from `.trb` tower fields.
     """
     sim = load_qblade_simulation_definition(sim_path)
     if not sim["turbfile_path"]:
@@ -366,6 +373,38 @@ def convert_qblade_to_vorlap_inputs(
                 qblade_node_ids.append(f"STR_{istruct + 1}_{iblade + 1}_0.000000")
                 qblade_node_ids.append(f"STR_{istruct + 1}_{iblade + 1}_1.000000")
 
+    if include_tower:
+        tower_height = float(trb.get("tower_height", 0.0) or 0.0)
+        tower_top_radius = float(trb.get("tower_top_radius", 0.0) or 0.0)
+        tower_bottom_radius = float(trb.get("tower_bottom_radius", 0.0) or 0.0)
+        if tower_height > 0.0 and (tower_top_radius > 0.0 or tower_bottom_radius > 0.0):
+            n_tower = max(6, len(heights))
+            # Align tower top with the blade hub reference height in the imported geometry.
+            hub_z_ref = float(np.mean(heights)) if heights.size else 0.0
+            t = np.linspace(0.0, 1.0, n_tower, dtype=float)
+            z = hub_z_ref - tower_height + tower_height * t
+            radii_tower = tower_bottom_radius + (tower_top_radius - tower_bottom_radius) * t
+            chord_tower = np.maximum(2.0 * radii_tower, 1.0e-3)
+
+            tower_component = Component(
+                id="TWR_1",
+                translation=np.zeros(3, dtype=float),
+                rotation=np.zeros(3, dtype=float),
+                pitch=np.array([0.0], dtype=float),
+                shape_xyz=np.column_stack([np.zeros_like(z), np.zeros_like(z), z]),
+                shape_xyz_global=np.zeros((n_tower, 3), dtype=float),
+                chord=chord_tower,
+                twist=np.zeros(n_tower, dtype=float),
+                thickness=np.ones(n_tower, dtype=float),
+                offset=np.full(n_tower, 0.5, dtype=float),
+                airfoil_ids=[tower_airfoil_id] * n_tower,
+                chord_vector=np.zeros((n_tower, 3), dtype=float),
+                normal_vector=np.zeros((n_tower, 3), dtype=float),
+            )
+            components.append(tower_component)
+            for p in t:
+                qblade_node_ids.append(f"TWR_1_{float(p):.6f}")
+
     hor_rad = np.deg2rad(float(sim["hor_angle_deg"]))
     vert_rad = np.deg2rad(float(sim["vert_angle_deg"]))
     inflow_vec = np.array(
@@ -399,6 +438,92 @@ def convert_qblade_to_vorlap_inputs(
     )
 
     return components, viv_params, qblade_node_ids
+
+
+def write_components_to_csv(dir_path: str, components: List[Component]) -> List[str]:
+    """
+    Write VorLap components to per-component CSV files compatible with `load_components_from_csv`.
+
+    Args:
+        dir_path: Output directory for component CSV files.
+        components: Components to write.
+
+    Returns:
+        List of absolute file paths written.
+    """
+    if not components:
+        raise ValueError("No components were provided for export.")
+
+    os.makedirs(dir_path, exist_ok=True)
+    written_files: List[str] = []
+
+    for icomp, comp in enumerate(components):
+        comp_id = str(comp.id) if getattr(comp, "id", None) else f"component_{icomp+1}"
+        safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", comp_id).strip("_") or f"component_{icomp+1}"
+        out_path = os.path.abspath(os.path.join(dir_path, f"{safe_id}.csv"))
+
+        xyz = np.asarray(comp.shape_xyz, dtype=float)
+        if xyz.ndim != 2 or xyz.shape[1] != 3:
+            raise ValueError(f"Component '{comp_id}' has invalid shape_xyz with shape {xyz.shape}.")
+
+        npts = xyz.shape[0]
+        chord = np.asarray(comp.chord, dtype=float).reshape(-1)
+        twist = np.asarray(comp.twist, dtype=float).reshape(-1)
+        thickness = np.asarray(comp.thickness, dtype=float).reshape(-1)
+        offset = np.asarray(comp.offset, dtype=float).reshape(-1)
+        if not (len(chord) == len(twist) == len(thickness) == len(offset) == npts):
+            raise ValueError(
+                f"Component '{comp_id}' has inconsistent vector lengths: "
+                f"xyz={npts}, chord={len(chord)}, twist={len(twist)}, thickness={len(thickness)}, offset={len(offset)}."
+            )
+
+        airfoil_ids = list(comp.airfoil_ids) if getattr(comp, "airfoil_ids", None) is not None else []
+        if len(airfoil_ids) < npts:
+            fill_id = airfoil_ids[-1] if airfoil_ids else "default"
+            airfoil_ids = airfoil_ids + [fill_id] * (npts - len(airfoil_ids))
+        else:
+            airfoil_ids = airfoil_ids[:npts]
+
+        translation = np.asarray(comp.translation, dtype=float).reshape(-1)
+        rotation = np.asarray(comp.rotation, dtype=float).reshape(-1)
+        pitch = np.asarray(comp.pitch, dtype=float).reshape(-1)
+        pitch_value = float(pitch[0]) if pitch.size else 0.0
+        if translation.size != 3 or rotation.size != 3:
+            raise ValueError(f"Component '{comp_id}' has invalid translation/rotation dimensions.")
+
+        with open(out_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(["id", "translation_x", "translation_y", "translation_z", "rotation_x", "rotation_y", "rotation_z", "pitch"])
+            writer.writerow(
+                [
+                    comp_id,
+                    f"{translation[0]:.9g}",
+                    f"{translation[1]:.9g}",
+                    f"{translation[2]:.9g}",
+                    f"{rotation[0]:.9g}",
+                    f"{rotation[1]:.9g}",
+                    f"{rotation[2]:.9g}",
+                    f"{pitch_value:.9g}",
+                ]
+            )
+            writer.writerow(["x", "y", "z", "chord", "twist", "thickness", "offset", "airfoil_id"])
+            for i in range(npts):
+                writer.writerow(
+                    [
+                        f"{xyz[i, 0]:.9g}",
+                        f"{xyz[i, 1]:.9g}",
+                        f"{xyz[i, 2]:.9g}",
+                        f"{chord[i]:.9g}",
+                        f"{twist[i]:.9g}",
+                        f"{thickness[i]:.9g}",
+                        f"{offset[i]:.9g}",
+                        str(airfoil_ids[i]),
+                    ]
+                )
+
+        written_files.append(out_path)
+
+    return written_files
 
 
 def write_qblade_loading_file(

--- a/vorlap/graphics.py
+++ b/vorlap/graphics.py
@@ -19,7 +19,7 @@ def calc_structure_vectors_andplot(
     return_fig: bool = False,
     components_black: bool = False,
     save_path: Optional[str] = None,
-):
+) -> Optional[go.Figure]:
     """
     Calculates structure vectors and creates a plot.
 
@@ -33,7 +33,7 @@ def calc_structure_vectors_andplot(
             static image is written.
 
     Returns:
-        fig: Plotly figure object if return_fig=True, otherwise None.
+        Optional[go.Figure]: Plotly figure object if return_fig=True, otherwise None.
     """
     from .fileio import load_airfoil_coords
 

--- a/vorlap/gui/app.py
+++ b/vorlap/gui/app.py
@@ -21,44 +21,81 @@ class VorLapApp(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("VORtex overLAP Tool")
-        self.geometry("1300x1200")
-        self.minsize(1300, 1200)
+        self.geometry("1300x980")
+        self.minsize(1100, 780)
 
-        # Apply modern theme and styling
-        setup_theme_and_styling(self)
+        # Default to light theme.
+        self.light_mode = tk.BooleanVar(value=True)
+        setup_theme_and_styling(self, mode="light")
 
         # Initialize data containers
         self.components = []
         self.natural_frequencies = None
         self.analysis_results = None
 
-        # Use grid for proper resizing behavior
-        self.rowconfigure(0, weight=1, minsize=100)   # Notebook expands with minimum size
-        self.rowconfigure(1, weight=0)   # Console has fixed size
+        # Use grid for proper resizing behavior.
+        self.rowconfigure(0, weight=0)   # Top bar
+        self.rowconfigure(1, weight=1)   # Notebook
+        self.rowconfigure(2, weight=0)   # Console
         self.columnconfigure(0, weight=1)
 
-        # Create notebook with padding
-        nb = ttk.Notebook(self)
-        nb.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 0))
+        # Top bar with theme toggle.
+        top_bar = ttk.Frame(self)
+        top_bar.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 0))
+        top_bar.columnconfigure(0, weight=1)
+        ttk.Label(top_bar, text="Theme").grid(row=0, column=1, padx=(0, 6))
+        ttk.Checkbutton(
+            top_bar,
+            text="Light",
+            variable=self.light_mode,
+            command=self.toggle_theme,
+        ).grid(row=0, column=2, sticky="e")
 
-        self.tab_setup = SimulationSetupTab(nb, self)
+        # Create notebook with padding.
+        self.nb = ttk.Notebook(self)
+        self.nb.grid(row=1, column=0, sticky="nsew", padx=8, pady=(8, 0))
+
+        self.tab_setup = SimulationSetupTab(self.nb, self)
         # self.tab_geometry = GeometryTab(nb, self)
-        self.tab_plots = PlotsOutputsTab(nb, self)
+        self.tab_plots = PlotsOutputsTab(self.nb, self)
         # self.tab_analysis = AnalysisTab(nb, self)
 
-        nb.add(self.tab_setup, text="Simulation Setup")
+        self.nb.add(self.tab_setup, text="Simulation Setup")
         # nb.add(self.tab_geometry, text="Geometry")
-        nb.add(self.tab_plots, text="Plots & Outputs")
+        self.nb.add(self.tab_plots, text="Plots & Outputs")
         # nb.add(self.tab_analysis, text="Analysis")
+        self.nb.bind("<<NotebookTabChanged>>", self._on_tab_changed)
 
         # Persistent console (non-collapsible)
         console_frame = ttk.LabelFrame(self, text="Console Output")
-        console_frame.grid(row=1, column=0, sticky="ew", padx=8, pady=(0, 8))
+        console_frame.grid(row=2, column=0, sticky="ew", padx=8, pady=(0, 8))
         console_frame.configure(height=200)  # Set fixed height
         console_frame.pack_propagate(False)  # Prevent shrinking
         
         self.console = ScrollText(console_frame, height=8)
         self.console.pack(fill="both", expand=True, padx=8, pady=8)
+
+    def toggle_theme(self):
+        mode = "light" if self.light_mode.get() else "dark"
+        setup_theme_and_styling(self, mode=mode)
+
+    def _on_tab_changed(self, event):
+        try:
+            tab_widget = event.widget.nametowidget(event.widget.select())
+            def _refresh():
+                try:
+                    if hasattr(tab_widget, "on_tab_selected"):
+                        tab_widget.on_tab_selected()
+                    if hasattr(tab_widget, "scrollable"):
+                        tab_widget.scrollable.refresh()
+                    tab_widget.update_idletasks()
+                    self.update_idletasks()
+                except Exception:
+                    pass
+            self.after_idle(_refresh)
+            self.after(30, _refresh)
+        except Exception:
+            pass
 
     def log(self, s: str):
         """Log message to console and status bar."""

--- a/vorlap/gui/styles.py
+++ b/vorlap/gui/styles.py
@@ -1,177 +1,167 @@
 #!/usr/bin/env python3
 """
 Theme and styling configuration for the VorLap GUI.
-
-This module contains all the styling configuration to maintain a consistent look.
 """
 
 from tkinter import ttk
 
-def setup_theme_and_styling(root):
-    """Set up modern theme and improved styling."""
+
+THEME_COLORS = {
+    "dark": {
+        "bg": "#1e1e1e",
+        "fg": "#d4d4d4",
+        "muted_fg": "#a0a0a0",
+        "select_bg": "#264f78",
+        "select_fg": "#ffffff",
+        "frame_bg": "#252526",
+        "panel_bg": "#2d2d2d",
+        "button_bg": "#3c3c3c",
+        "button_active": "#4e4e4e",
+        "entry_bg": "#1f1f1f",
+        "text_bg": "#1f1f1f",
+        "tree_bg": "#252526",
+        "tree_select": "#264f78",
+        "border": "#3c3c3c",
+    },
+    "light": {
+        "bg": "#f0f4f8",
+        "fg": "#1f2937",
+        "muted_fg": "#4b5563",
+        "select_bg": "#2563eb",
+        "select_fg": "#ffffff",
+        "frame_bg": "#ffffff",
+        "panel_bg": "#ffffff",
+        "button_bg": "#e2e8f0",
+        "button_active": "#cbd5e1",
+        "entry_bg": "#ffffff",
+        "text_bg": "#ffffff",
+        "tree_bg": "#ffffff",
+        "tree_select": "#dbeafe",
+        "border": "#94a3b8",
+    },
+}
+
+
+def setup_theme_and_styling(root, mode="dark"):
+    """Apply all ttk styling for the selected theme mode."""
+    mode = mode if mode in THEME_COLORS else "dark"
+    colors = THEME_COLORS[mode]
     style = ttk.Style(root)
-    
-    # Try to use the best available theme
+
     available_themes = style.theme_names()
-    preferred_themes = ["arc", "equilux", "adapta", "clam", "alt", "default"]
-    
+    preferred_themes = ["clam", "alt", "default"]
     selected_theme = "default"
     for theme in preferred_themes:
         if theme in available_themes:
             selected_theme = theme
             break
-    
     style.theme_use(selected_theme)
-    
-    # Configure colors for a modern look
-    colors = {
-        'bg': '#f0f0f0',           # Light gray background
-        'fg': '#2d3748',           # Dark gray text
-        'select_bg': '#4299e1',    # Blue selection
-        'select_fg': '#ffffff',    # White selected text
-        'frame_bg': '#ffffff',     # White frame background
-        'button_bg': '#e2e8f0',    # Light button background
-        'button_active': '#cbd5e0', # Button active state
-        'entry_bg': '#ffffff',     # White entry background
-        'tree_bg': '#ffffff',      # White treeview background
-        'tree_select': '#e2e8f0'   # Light gray tree selection
-    }
-    
-    # Configure styles with larger fonts
-    base_font = ('Segoe UI', 10)
-    large_font = ('Segoe UI', 12)
-    heading_font = ('Segoe UI', 11, 'bold')
-    
-    # Configure root window
-    root.configure(bg=colors['bg'])
-    
-    # Configure notebook (tabs)
-    style.configure('TNotebook', 
-                   background=colors['bg'],
-                   borderwidth=0)
-    style.configure('TNotebook.Tab',
-                   padding=[20, 8],
-                   font=heading_font,
-                   background=colors['button_bg'],
-                   foreground=colors['fg'])
-    style.map('TNotebook.Tab',
-             background=[('selected', colors['frame_bg']),
-                       ('active', colors['button_active'])])
-    
-    # Configure frames
-    style.configure('TFrame',
-                   background=colors['bg'])
-    
-    # Configure labels with larger font
-    style.configure('TLabel',
-                   font=base_font,
-                   background=colors['bg'],
-                   foreground=colors['fg'])
-    
-    # Configure LabelFrame with larger font
-    style.configure('TLabelframe',
-                   font=heading_font,
-                   background=colors['bg'],
-                   foreground=colors['fg'],
-                   borderwidth=1,
-                   relief='solid')
-    style.configure('TLabelframe.Label',
-                   font=heading_font,
-                   background=colors['bg'],
-                   foreground=colors['fg'])
-    
-    # Configure buttons with improved styling
-    style.configure('TButton',
-                   font=base_font,
-                   padding=[12, 6],
-                   background=colors['button_bg'],
-                   foreground=colors['fg'],
-                   borderwidth=1,
-                   relief='solid')
-    style.map('TButton',
-             background=[('active', colors['button_active']),
-                       ('pressed', colors['select_bg'])],
-             foreground=[('pressed', colors['select_fg'])])
-    
-    # Configure entries with larger font
-    style.configure('TEntry',
-                   font=base_font,
-                   fieldbackground=colors['entry_bg'],
-                   foreground=colors['fg'],
-                   borderwidth=1,
-                   relief='solid',
-                   insertwidth=2)
-    style.map('TEntry',
-             focuscolor=[('!focus', 'none')])
-    
-    # Configure spinbox
-    style.configure('TSpinbox',
-                   font=base_font,
-                   fieldbackground=colors['entry_bg'],
-                   foreground=colors['fg'],
-                   borderwidth=1,
-                   relief='solid')
-    
-    # Configure treeview with larger font
-    style.configure('Treeview',
-                   font=base_font,
-                   background=colors['tree_bg'],
-                   foreground=colors['fg'],
-                   fieldbackground=colors['tree_bg'],
-                   borderwidth=1,
-                   relief='solid')
-    style.configure('Treeview.Heading',
-                   font=heading_font,
-                   background=colors['button_bg'],
-                   foreground=colors['fg'],
-                   borderwidth=1,
-                   relief='solid')
-    style.map('Treeview',
-             background=[('selected', colors['tree_select'])],
-             foreground=[('selected', colors['fg'])])
-    
-    # Configure scrollbars
-    style.configure('TScrollbar',
-                   background=colors['button_bg'],
-                   troughcolor=colors['bg'],
-                   borderwidth=1,
-                   relief='solid')
-    
-    # Configure radiobuttons with larger font
-    style.configure('TRadiobutton',
-                   font=base_font,
-                   background=colors['bg'],
-                   foreground=colors['fg'],
-                   focuscolor='none')
-    
-    # Configure checkbuttons with larger font
-    style.configure('TCheckbutton',
-                   font=base_font,
-                   background=colors['bg'],
-                   foreground=colors['fg'],
-                   focuscolor='none')
-    style.configure('Accent.TCheckbutton',
-                   font=base_font,
-                   background=colors['bg'],
-                   foreground=colors['select_bg'],
-                   focuscolor='none')
-    
-    # Configure progressbar (if used)
-    style.configure('TProgressbar',
-                   background=colors['select_bg'],
-                   troughcolor=colors['button_bg'],
-                   borderwidth=0)
-    
-    # Configure separators
-    style.configure('TSeparator',
-                   background=colors['button_bg'])
-    
-    # Configure status bar
-    style.configure('StatusFrame.TFrame',
-                   background=colors['frame_bg'],
-                   borderwidth=1,
-                   relief='solid')
-    style.configure('Status.TLabel',
-                   font=base_font,
-                   background=colors['frame_bg'],
-                   foreground=colors['fg']) 
+
+    base_font = ("Segoe UI", 10)
+    heading_font = ("Segoe UI", 11, "bold")
+    tab_font = ("Segoe UI", 11, "bold")
+
+    root.configure(bg=colors["bg"])
+    root._vorlap_theme_mode = mode
+    root._vorlap_theme_colors = colors
+
+    style.configure("TFrame", background=colors["bg"])
+    style.configure("TLabel", font=base_font, background=colors["bg"], foreground=colors["fg"])
+
+    style.configure(
+        "TLabelframe",
+        font=heading_font,
+        background=colors["bg"],
+        foreground=colors["fg"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure(
+        "TLabelframe.Label",
+        font=heading_font,
+        background=colors["bg"],
+        foreground=colors["fg"],
+    )
+
+    style.configure(
+        "TButton",
+        font=base_font,
+        padding=[10, 6],
+        background=colors["button_bg"],
+        foreground=colors["fg"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "TButton",
+        background=[("active", colors["button_active"]), ("pressed", colors["select_bg"])],
+        foreground=[("pressed", colors["select_fg"])],
+    )
+
+    style.configure(
+        "TEntry",
+        font=base_font,
+        fieldbackground=colors["entry_bg"],
+        foreground=colors["fg"],
+        insertcolor=colors["fg"],
+        borderwidth=1,
+        relief="solid",
+    )
+
+    style.configure(
+        "TNotebook",
+        background=colors["bg"],
+        borderwidth=0,
+    )
+    style.configure(
+        "TNotebook.Tab",
+        font=tab_font,
+        padding=[16, 7],
+        background=colors["button_bg"],
+        foreground=colors["fg"],
+    )
+    style.map(
+        "TNotebook.Tab",
+        background=[("selected", colors["panel_bg"]), ("active", colors["button_active"])],
+        foreground=[("selected", colors["fg"])],
+        padding=[("selected", [24, 11]), ("!selected", [16, 7])],
+    )
+
+    style.configure(
+        "Treeview",
+        font=base_font,
+        background=colors["tree_bg"],
+        foreground=colors["fg"],
+        fieldbackground=colors["tree_bg"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure(
+        "Treeview.Heading",
+        font=heading_font,
+        background=colors["button_bg"],
+        foreground=colors["fg"],
+        borderwidth=1,
+        relief="solid",
+    )
+    style.map(
+        "Treeview",
+        background=[("selected", colors["tree_select"])],
+        foreground=[("selected", colors["fg"] if mode == "light" else "#0f172a")],
+    )
+
+    style.configure(
+        "TScrollbar",
+        background=colors["button_bg"],
+        troughcolor=colors["bg"],
+        borderwidth=1,
+        relief="solid",
+    )
+
+    style.configure("TRadiobutton", font=base_font, background=colors["bg"], foreground=colors["fg"])
+    style.configure("TCheckbutton", font=base_font, background=colors["bg"], foreground=colors["fg"])
+
+    style.configure("StatusFrame.TFrame", background=colors["frame_bg"], borderwidth=1, relief="solid")
+    style.configure("Status.TLabel", font=base_font, background=colors["frame_bg"], foreground=colors["fg"])
+
+    root.event_generate("<<VorLapThemeChanged>>", when="tail")

--- a/vorlap/gui/tabs/plots.py
+++ b/vorlap/gui/tabs/plots.py
@@ -6,19 +6,19 @@ This tab handles visualization, plotting, and data export functionality.
 """
 
 import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
-from pathlib import Path
+from tkinter import ttk, messagebox, filedialog
+
+import numpy as np
 import matplotlib.colors as mcolors
 
 import vorlap
 
-from ..widgets import PathEntry
+from ..widgets import ScrollableFrame, PathEntry
 
 # --- Optional plotting support ---
 try:
-    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
     from matplotlib.figure import Figure
-    import matplotlib.pyplot as plt
     MATPLOTLIB_OK = True
 except Exception:
     MATPLOTLIB_OK = False
@@ -28,150 +28,433 @@ class PlotsOutputsTab(ttk.Frame):
     def __init__(self, master, app):
         super().__init__(master)
         self.app = app
+        self.scrollable = ScrollableFrame(self)
+        self.scrollable.pack(fill="both", expand=True)
+        self.content = self.scrollable.content
+        self._colorbar = None
+        self.toolbar = None
+        self._last_plot_save_path = ""
         self._build()
 
     def _build(self):
-        # Center-left: Plot area
-        self.plot_frame = ttk.LabelFrame(self, text="Analysis Results")
-        self.plot_frame.grid(row=1, column=0, columnspan=3, sticky="nsew", padx=10, pady=6)
-        
+        container = self.content
+
+        top_actions = ttk.LabelFrame(container, text="Run and Outputs")
+        top_actions.grid(row=0, column=0, sticky="ew", padx=10, pady=(6, 2))
+        top_actions.columnconfigure(1, weight=1)
+        top_actions.columnconfigure(3, weight=1)
+
+        ttk.Button(top_actions, text="Run and Plot", command=self.run_and_plot).grid(
+            row=0, column=0, sticky="w", padx=(6, 8), pady=(6, 4)
+        )
+        ttk.Label(top_actions, text="Run analysis then switch plot types below.").grid(
+            row=0, column=1, columnspan=3, sticky="w", pady=(6, 4)
+        )
+
+        ttk.Label(top_actions, text="Output Directory").grid(row=1, column=0, sticky="w", padx=(6, 4))
+        self.output_dir_entry = PathEntry(
+            top_actions,
+            kind="dir",
+            title="Choose output directory",
+            must_exist=True,
+            textvariable=self.app.tab_setup.sim_save_var,
+        )
+        self.output_dir_entry.grid(row=1, column=1, sticky="ew", padx=(0, 8), pady=(0, 4))
+
+        ttk.Label(top_actions, text="QBlade Loading Output (optional)").grid(row=1, column=2, sticky="w", padx=(0, 4))
+        self.qblade_loading_entry = PathEntry(
+            top_actions,
+            kind="savefile",
+            title="Choose QBlade loading output file",
+            must_exist=False,
+            textvariable=self.app.tab_setup.qblade_loading_path_var,
+        )
+        self.qblade_loading_entry.grid(row=1, column=3, sticky="ew", padx=(0, 6), pady=(0, 4))
+
+        self.plot_frame = ttk.LabelFrame(container, text="Analysis Results")
+        self.plot_frame.grid(row=1, column=0, sticky="nsew", padx=10, pady=6)
+        self.plot_frame.columnconfigure(0, weight=1)
+        self.plot_frame.rowconfigure(1, weight=1)
+
+        controls = ttk.Frame(self.plot_frame)
+        controls.grid(row=0, column=0, sticky="ew", padx=5, pady=5)
+        ttk.Label(controls, text="Plot Type:").grid(row=0, column=0, sticky="w")
+
+        self.plot_type = tk.StringVar(value="geometry")
+        plot_types = [
+            ("Geometry", "geometry"),
+            ("Frequency Overlap", "percdiff"),
+            ("Force X", "fx"),
+            ("Force Y", "fy"),
+            ("Force Z", "fz"),
+            ("Moment X", "mx"),
+            ("Moment Y", "my"),
+            ("Moment Z", "mz"),
+        ]
+        for i, (text, value) in enumerate(plot_types):
+            ttk.Radiobutton(
+                controls,
+                text=text,
+                variable=self.plot_type,
+                value=value,
+                command=self._on_plot_type_changed,
+            ).grid(row=0, column=i + 1, padx=4)
+
+        self.fancy_geometry_btn = ttk.Button(
+            controls,
+            text="Fancy Geometry",
+            command=self.open_fancy_geometry,
+        )
+        self.fancy_geometry_btn.grid(row=1, column=1, pady=(4, 0), sticky="w")
+        ttk.Button(controls, text="Save Plot", command=self.save_plot).grid(row=0, column=len(plot_types) + 1, padx=5)
 
         self.fig = Figure(figsize=(10, 8))
         self.ax = self.fig.add_subplot(111)
         self.ax.set_title("VorLap Analysis Results")
-        self.ax.text(0.5, 0.5, "Run analysis to see results", ha='center', va='center', transform=self.ax.transAxes)
-        
+        self.ax.text(0.5, 0.5, "Run analysis to see results", ha="center", va="center", transform=self.ax.transAxes)
+        self._apply_axis_theme(self.ax)
+
         self.canvas = FigureCanvasTkAgg(self.fig, master=self.plot_frame)
         self.canvas.draw()
         self.canvas.get_tk_widget().grid(row=1, column=0, sticky="nsew")
-        
-        # Configure plot frame grid weights
-        self.plot_frame.columnconfigure(0, weight=1)
-        self.plot_frame.rowconfigure(1, weight=1)
-        
-        # Initialize colorbar attribute
-        self._colorbar = None
 
-        # Plot type selection
-        plot_controls = ttk.Frame(self.plot_frame)
-        plot_controls.grid(row=0, column=0, sticky="ew", padx=5, pady=5)
-        
-        ttk.Label(plot_controls, text="Plot Type:").grid(row=0, column=0, sticky="w")
-        
-        self.plot_type = tk.StringVar(value="percdiff")
-        plot_types = [
-            ("Frequency Overlap", "percdiff"),
-            ("Force X", "fx"),
-            ("Force Y", "fy"), 
-            ("Force Z", "fz"),
-            ("Moment X", "mx"),
-            ("Moment Y", "my"),
-            ("Moment Z", "mz")
-        ]
-        
-        for i, (text, value) in enumerate(plot_types):
-            ttk.Radiobutton(plot_controls, text=text, variable=self.plot_type, 
-                          value=value, command=self.update_plots).grid(row=0, column=i+1, padx=5)
-        
-        # Add save button
-        ttk.Button(plot_controls, text="Save Plot", command=self.save_plot).grid(row=0, column=len(plot_types)+1, padx=5)
+        self.toolbar_frame = ttk.Frame(self.plot_frame)
+        self.toolbar_frame.grid(row=2, column=0, sticky="ew")
+        self._refresh_toolbar()
 
-        # Bottom: Sample controls + export path + Export button
-        # weights
-        self.columnconfigure(1, weight=1)
-        self.rowconfigure(1, weight=1)
+        container.columnconfigure(0, weight=1)
+        container.rowconfigure(1, weight=1)
 
+        self.winfo_toplevel().bind("<<VorLapThemeChanged>>", self._on_theme_changed, add="+")
+        self._update_geometry_controls()
 
-    def update_plots(self):
-        """Update the plot based on current analysis results and selected plot type."""
-        if not hasattr(self.app, 'analysis_results') or not self.app.analysis_results:
+    def _on_plot_type_changed(self):
+        self._update_geometry_controls()
+        self.update_plots()
+
+    def _update_geometry_controls(self):
+        if self.plot_type.get() == "geometry":
+            self.fancy_geometry_btn.state(["!disabled"])
+        else:
+            self.fancy_geometry_btn.state(["disabled"])
+
+    def _on_theme_changed(self, _event=None):
+        if self.canvas:
+            self.update_plots(show_errors=False)
+
+    def _theme_colors(self):
+        return getattr(
+            self.app,
+            "_vorlap_theme_colors",
+            {
+                "bg": "#1e1e1e",
+                "fg": "#d4d4d4",
+                "panel_bg": "#2d2d2d",
+                "text_bg": "#1f1f1f",
+            },
+        )
+
+    def _apply_axis_theme(self, axis, is_3d=False):
+        colors = self._theme_colors()
+        self.fig.patch.set_facecolor(colors["bg"])
+        axis.set_facecolor(colors["text_bg"])
+        axis.tick_params(colors=colors["fg"])
+        axis.xaxis.label.set_color(colors["fg"])
+        axis.yaxis.label.set_color(colors["fg"])
+        axis.title.set_color(colors["fg"])
+
+        if is_3d and hasattr(axis, "zaxis"):
+            axis.zaxis.label.set_color(colors["fg"])
+            try:
+                axis.xaxis.pane.set_facecolor((0.10, 0.13, 0.20, 0.35))
+                axis.yaxis.pane.set_facecolor((0.10, 0.13, 0.20, 0.35))
+                axis.zaxis.pane.set_facecolor((0.10, 0.13, 0.20, 0.35))
+            except Exception:
+                pass
+            try:
+                axis.zaxis.set_tick_params(colors=colors["fg"])
+            except Exception:
+                pass
+
+    def _refresh_toolbar(self):
+        if not MATPLOTLIB_OK:
             return
-            
-        results = self.app.analysis_results
-        plot_type = self.plot_type.get()
-        viv_params = results['viv_params']
-        
-        # Create a completely fresh figure and canvas
-        self.fig = Figure(figsize=(10, 8))
-        self.ax = self.fig.add_subplot(111)
-        
-        extent = [viv_params.azimuths[0], viv_params.azimuths[-1], 
-                 viv_params.inflow_speeds[0], viv_params.inflow_speeds[-1]]
-        
-        if plot_type == "percdiff":
-            data = results['percdiff_matrix']
-            im = self.ax.imshow(data, extent=extent, aspect='auto', origin='lower', 
-                               cmap='viridis_r', vmin=0, vmax=50)
-            self.ax.set_title('Worst Percent Difference')
-            label = 'Freq % Diff'
-        elif plot_type.startswith("f"):
-            force_data = results['total_global_force_vector']
-            idx = {'fx': 0, 'fy': 1, 'fz': 2}[plot_type]
-            data = force_data[:, :, idx]
-            # Force grey at 0, blue for negatives, red for positives
-            norm = mcolors.TwoSlopeNorm(vmin=data.min(), vcenter=0.0, vmax=data.max())
+        for child in self.toolbar_frame.winfo_children():
+            child.destroy()
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self.toolbar_frame)
+        self.toolbar.update()
 
-            im = self.ax.imshow(
-                data,
-                extent=extent,
-                aspect='auto',
-                origin='lower',
-                cmap='coolwarm',
-                norm=norm
-            )
-            self.ax.set_title(f'Force {plot_type.upper()}')
-            label = 'Force (N)'
-        elif plot_type.startswith("m"):
-            moment_data = results['total_global_moment_vector']
-            idx = {'mx': 0, 'my': 1, 'mz': 2}[plot_type]
-            data = moment_data[:, :, idx]
-            # Force grey at 0, blue for negatives, red for positives
-            norm = mcolors.TwoSlopeNorm(vmin=data.min(), vcenter=0.0, vmax=data.max())
+    def run_and_plot(self):
+        self.app.nb.select(self)
+        self.plot_type.set("percdiff")
+        self._update_geometry_controls()
+        self.app.tab_setup.run_and_save()
 
-            im = self.ax.imshow(
-                data,
-                extent=extent,
-                aspect='auto',
-                origin='lower',
-                cmap='coolwarm',
-                norm=norm
+    def open_fancy_geometry(self):
+        if not self.app.components:
+            messagebox.showwarning("No Data", "Load geometry and run analysis first.")
+            return
+        try:
+            results = self.app.analysis_results or {}
+            viv_params = results.get("viv_params", self.app.tab_setup.get_viv_params())
+            fig = vorlap.graphics.calc_structure_vectors_andplot(
+                self.app.components,
+                viv_params,
+                show_plot=False,
+                return_fig=True,
             )
-            self.ax.set_title(f'Moment {plot_type.upper()}')
-            label = 'Moment (N-m)'
-        
-        self.ax.set_xlabel('Azimuth (deg)')
-        self.ax.set_ylabel('Inflow (m/s)')
-        
-        # Add colorbar to the fresh figure
-        self._colorbar = self.fig.colorbar(im, ax=self.ax, label=label)
-        
-        # Destroy the old canvas and create a new one with the fresh figure
+            if fig is not None:
+                fig.show(renderer="browser")
+        except Exception as exc:
+            self.app.log(f"Fancy geometry failed: {exc}\n")
+            messagebox.showerror("Fancy Geometry Error", str(exc))
+
+    def on_tab_selected(self):
+        try:
+            self.update_idletasks()
+            self.scrollable.refresh()
+            if self.canvas:
+                self.canvas.draw_idle()
+        except Exception:
+            pass
+
+    def _create_norm(self, data):
+        data = np.asarray(data, dtype=float)
+        vmin = float(np.nanmin(data))
+        vmax = float(np.nanmax(data))
+        if np.isclose(vmin, vmax):
+            eps = max(abs(vmin) * 0.01, 1e-6)
+            return mcolors.Normalize(vmin=vmin - eps, vmax=vmax + eps)
+        if vmin < 0.0 < vmax:
+            return mcolors.TwoSlopeNorm(vmin=vmin, vcenter=0.0, vmax=vmax)
+        return mcolors.Normalize(vmin=vmin, vmax=vmax)
+
+    def _set_axes_equal_3d(self, axis, points):
+        pts = np.vstack(points)
+        mins = pts.min(axis=0)
+        maxs = pts.max(axis=0)
+        center = (mins + maxs) / 2.0
+        span = np.max(maxs - mins)
+        if span <= 0:
+            span = 1.0
+        half = span * 0.55
+        axis.set_xlim(center[0] - half, center[0] + half)
+        axis.set_ylim(center[1] - half, center[1] + half)
+        axis.set_zlim(center[2] - half, center[2] + half)
+
+    def _plot_geometry(self):
+        if not self.app.components:
+            raise ValueError("No components loaded. Load geometry and run analysis first.")
+
+        results = self.app.analysis_results or {}
+        viv_params = results.get("viv_params", self.app.tab_setup.get_viv_params())
+
+        # Populate shape_xyz_global/chord_vector/normal_vector consistently.
+        vorlap.graphics.calc_structure_vectors_andplot(
+            self.app.components,
+            viv_params,
+            show_plot=False,
+            return_fig=False,
+        )
+
+        points = []
+        for comp in self.app.components:
+            comp_pts = np.asarray(comp.shape_xyz_global, dtype=float)
+            if comp_pts.ndim != 2 or comp_pts.shape[1] != 3 or comp_pts.shape[0] == 0:
+                continue
+            points.append(comp_pts)
+            self.ax.plot(comp_pts[:, 0], comp_pts[:, 1], comp_pts[:, 2], color="#60a5fa", linewidth=2.2, alpha=0.95)
+
+            nseg = min(len(comp_pts), len(comp.chord_vector), len(comp.normal_vector))
+            step = max(1, nseg // 18)
+            for i in range(0, nseg, step):
+                p = comp_pts[i]
+                chord = np.asarray(comp.chord_vector[i], dtype=float)
+                normal = np.asarray(comp.normal_vector[i], dtype=float)
+                chord_norm = np.linalg.norm(chord)
+                normal_norm = np.linalg.norm(normal)
+                if chord_norm > 1e-10:
+                    self.ax.quiver(
+                        p[0], p[1], p[2],
+                        chord[0], chord[1], chord[2],
+                        length=1.0,
+                        normalize=True,
+                        color="#22d3ee",
+                        linewidth=0.7,
+                        arrow_length_ratio=0.2,
+                    )
+                if normal_norm > 1e-10:
+                    self.ax.quiver(
+                        p[0], p[1], p[2],
+                        normal[0], normal[1], normal[2],
+                        length=1.0,
+                        normalize=True,
+                        color="#f97316",
+                        linewidth=0.7,
+                        arrow_length_ratio=0.2,
+                    )
+
+        if not points:
+            raise ValueError("Component geometry could not be rendered.")
+
+        stacked = np.vstack(points)
+        mins = stacked.min(axis=0)
+        maxs = stacked.max(axis=0)
+        span = np.max(maxs - mins)
+        if span <= 0:
+            span = 1.0
+
+        axis_dir = np.asarray(viv_params.rotation_axis, dtype=float)
+        axis_norm = np.linalg.norm(axis_dir)
+        if axis_norm > 1e-10:
+            axis_dir = axis_dir / axis_norm
+            origin = np.asarray(viv_params.rotation_axis_offset, dtype=float)
+            tip = origin + axis_dir * (0.75 * span)
+            self.ax.plot(
+                [origin[0], tip[0]],
+                [origin[1], tip[1]],
+                [origin[2], tip[2]],
+                color="#e2e8f0",
+                linestyle="--",
+                linewidth=1.4,
+            )
+
+        inflow_vec = np.asarray(viv_params.inflow_vec, dtype=float)
+        inflow_norm = np.linalg.norm(inflow_vec)
+        if inflow_norm > 1e-10:
+            inflow_vec = inflow_vec / inflow_norm
+            center = stacked.mean(axis=0)
+            start = center - inflow_vec * (0.35 * span)
+            self.ax.quiver(
+                start[0], start[1], start[2],
+                inflow_vec[0], inflow_vec[1], inflow_vec[2],
+                length=0.45 * span,
+                normalize=True,
+                color="#facc15",
+                linewidth=1.2,
+                arrow_length_ratio=0.2,
+            )
+
+        self._set_axes_equal_3d(self.ax, points)
+        self.ax.set_xlabel("X")
+        self.ax.set_ylabel("Y")
+        self.ax.set_zlabel("Z")
+        self.ax.set_title("Structure Geometry (drag to rotate)")
+        self._apply_axis_theme(self.ax, is_3d=True)
+
+    def _rebuild_canvas(self):
         old_canvas = self.canvas
         self.canvas = FigureCanvasTkAgg(self.fig, master=self.plot_frame)
         self.canvas.draw()
-        
-        # Replace the old canvas widget in the grid
         old_canvas.get_tk_widget().destroy()
         self.canvas.get_tk_widget().grid(row=1, column=0, sticky="nsew")
+        self._refresh_toolbar()
+
+    def update_plots(self, show_errors=True):
+        """Update the plot based on current analysis results and selected plot type."""
+        if not MATPLOTLIB_OK:
+            return
+
+        plot_type = self.plot_type.get()
+        results = self.app.analysis_results or {}
+        if plot_type != "geometry" and not results:
+            return
+
+        try:
+            self.fig = Figure(figsize=(10, 8))
+
+            if plot_type == "geometry":
+                self.ax = self.fig.add_subplot(111, projection="3d")
+                self._plot_geometry()
+                self._colorbar = None
+            else:
+                self.ax = self.fig.add_subplot(111)
+                viv_params = results["viv_params"]
+                extent = [
+                    viv_params.azimuths[0],
+                    viv_params.azimuths[-1],
+                    viv_params.inflow_speeds[0],
+                    viv_params.inflow_speeds[-1],
+                ]
+
+                if plot_type == "percdiff":
+                    data = results["percdiff_matrix"]
+                    im = self.ax.imshow(
+                        data,
+                        extent=extent,
+                        aspect="auto",
+                        origin="lower",
+                        cmap="viridis_r",
+                        vmin=0,
+                        vmax=50,
+                    )
+                    self.ax.set_title("Worst Percent Difference")
+                    label = "Freq % Diff"
+                elif plot_type.startswith("f"):
+                    force_data = results["total_global_force_vector"]
+                    idx = {"fx": 0, "fy": 1, "fz": 2}[plot_type]
+                    data = force_data[:, :, idx]
+                    im = self.ax.imshow(
+                        data,
+                        extent=extent,
+                        aspect="auto",
+                        origin="lower",
+                        cmap="coolwarm",
+                        norm=self._create_norm(data),
+                    )
+                    self.ax.set_title(f"Force {plot_type.upper()}")
+                    label = "Force (N)"
+                elif plot_type.startswith("m"):
+                    moment_data = results["total_global_moment_vector"]
+                    idx = {"mx": 0, "my": 1, "mz": 2}[plot_type]
+                    data = moment_data[:, :, idx]
+                    im = self.ax.imshow(
+                        data,
+                        extent=extent,
+                        aspect="auto",
+                        origin="lower",
+                        cmap="coolwarm",
+                        norm=self._create_norm(data),
+                    )
+                    self.ax.set_title(f"Moment {plot_type.upper()}")
+                    label = "Moment (N-m)"
+                else:
+                    raise ValueError(f"Unsupported plot type: {plot_type}")
+
+                self.ax.set_xlabel("Azimuth (deg)")
+                self.ax.set_ylabel("Inflow (m/s)")
+                self._apply_axis_theme(self.ax)
+                self._colorbar = self.fig.colorbar(im, ax=self.ax, label=label)
+                if self._colorbar is not None:
+                    self._colorbar.ax.yaxis.label.set_color(self._theme_colors()["fg"])
+                    self._colorbar.ax.tick_params(colors=self._theme_colors()["fg"])
+                    try:
+                        self._colorbar.outline.set_edgecolor(self._theme_colors()["fg"])
+                    except Exception:
+                        pass
+
+            self._rebuild_canvas()
+        except Exception as exc:
+            self.app.log(f"Plot update failed ({plot_type}): {exc}\n")
+            if show_errors:
+                messagebox.showerror("Plot Error", str(exc))
 
     # ---- handlers ----
     def save_plot(self):
         if not self.fig:
             messagebox.showinfo("Plot", "No Matplotlib figure available.")
             return
-        
-        # Get simulation save path from setup tab
-        sim_save_path = self.app.tab_setup.sim_save.get()
-        if not sim_save_path:
-            messagebox.showwarning("No Save Path", "Please set a simulation save path in the Setup tab first.")
-            return
-        
-        # Create plots subfolder in simulation directory
-        plots_dir = Path(sim_save_path) / "plots"
-        plots_dir.mkdir(exist_ok=True)
-        
-        plot_type = self.plot_type.get()
-        path = plots_dir / f"{plot_type}_plot.png"
-        self.fig.savefig(path, dpi=150, bbox_inches='tight')
-        self.app.log(f"Plot saved to: {path}\n")
 
+        suggested = self._last_plot_save_path.strip() or f"{self.plot_type.get()}_plot.png"
+        path = filedialog.asksaveasfilename(
+            title="Save plot image",
+            defaultextension=".png",
+            initialfile=suggested,
+            filetypes=[("PNG Image", "*.png"), ("PDF", "*.pdf"), ("SVG", "*.svg"), ("All Files", "*.*")],
+        )
+        if not path:
+            return
+        self._last_plot_save_path = path
+
+        self.fig.savefig(path, dpi=150, bbox_inches="tight")
+        self.app.log(f"Plot saved to: {path}\n")

--- a/vorlap/gui/tabs/setup.py
+++ b/vorlap/gui/tabs/setup.py
@@ -11,42 +11,42 @@ import os
 import numpy as np
 import time
 import threading
+import warnings
+from collections import Counter
 
 import vorlap
 
-from ..widgets import PathEntry, EditableTreeview
+from ..widgets import PathEntry, EditableTreeview, ScrollableFrame
 
 
 class SimulationSetupTab(ttk.Frame):
     def __init__(self, master, app):
         super().__init__(master)
         self.app = app
+        self.sim_save_var = tk.StringVar()
+        self.qblade_loading_path_var = tk.StringVar()
+        self.include_qblade_tower = tk.BooleanVar(value=True)
+        self.scrollable = ScrollableFrame(self)
+        self.scrollable.pack(fill="both", expand=True)
+        self.content = self.scrollable.content
         self._build()
 
     def _build(self):
-        # Top: Sim name/path + full sim save path + Run & Save
+        container = self.content
         row = 0
-        ttk.Label(self, text="Sim Name/Path").grid(row=row, column=0, sticky="w")
-        ttk.Label(self, text="Full Simulation Save Path").grid(row=row, column=2, sticky="w")
-        self.sim_save = PathEntry(self, kind="dir", title="Choose simulation save directory")
-        self.sim_save.grid(row=row, column=3, sticky="ew", padx=(6, 0))
-        
-        
-        self.run_btn = ttk.Button(self, text="Run & Save", command=self.run_and_save)
-        self.run_btn.grid(row=row, column=5, padx=6)
-        row += 1
-
-        # Add a separator
-        sep = ttk.Separator(self, orient='horizontal')
-        sep.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 0))
-        row += 1
         
         # Parked Modal Frequencies (simplified for single-row CSV)
-        lfreq = ttk.LabelFrame(self, text="Parked Modal Frequencies")
+        lfreq = ttk.LabelFrame(container, text="Parked Modal Frequencies")
         lfreq.grid(row=row, column=0, columnspan=6, sticky="nsew", pady=(10, 6))
         
         ttk.Label(lfreq, text="File Path").grid(row=0, column=0, sticky="w")
-        self.freq_path = PathEntry(lfreq, kind="file", title="Select frequency CSV", must_exist=True)
+        self.freq_path = PathEntry(
+            lfreq,
+            kind="file",
+            title="Select frequency CSV",
+            must_exist=True,
+            on_select=lambda _path: self.import_freq(),
+        )
         self.freq_path.grid(row=1, column=0, sticky="ew", pady=2)
         ttk.Button(lfreq, text="Import", command=self.import_freq).grid(row=1, column=1, padx=6)
         ttk.Label(lfreq, text="Frequencies [Hz]").grid(row=2, column=0, sticky="w", pady=(6, 0))
@@ -69,8 +69,102 @@ class SimulationSetupTab(ttk.Frame):
         lfreq.columnconfigure(0, weight=1)
         row += 1
 
+        # Simulation Parameters
+        lpars = ttk.LabelFrame(container, text="Simulation Parameters")
+        lpars.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
+        ttk.Label(lpars, text="File Path").grid(row=0, column=0, sticky="w")
+        self.param_path = PathEntry(
+            lpars,
+            kind="file",
+            title="Select parameters CSV",
+            must_exist=True,
+            on_select=lambda _path: self.import_params(),
+        )
+        self.param_path.grid(row=1, column=0, sticky="ew", pady=2)
+        ttk.Button(lpars, text="Import", command=self.import_params).grid(row=1, column=1, padx=6)
+        ttk.Label(lpars, text="Simulation Parameters List").grid(row=2, column=0, sticky="w", pady=(6, 0))
+        self.param_table = EditableTreeview(lpars, columns=["Description", "Parameter", "Value"], non_editable_columns=["Description"])
+        self.param_table.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(2, 0))
+        lpars.columnconfigure(0, weight=1)
+        lpars.rowconfigure(3, weight=0)  # Fixed weight for parameter table (non-collapsible)
+        row += 1
+
+        # Geometry source toggle + side-by-side inputs
+        lgeom = ttk.LabelFrame(container, text="Geometry Input Source")
+        lgeom.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
+        self.use_qblade_geometry = tk.BooleanVar(value=True)
+        ttk.Checkbutton(
+            lgeom,
+            text="QBlade Geometry",
+            variable=self.use_qblade_geometry,
+            command=self._on_qblade_toggle,
+        ).grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 6))
+
+        # QBlade simulation input (left)
+        self.qblade_frame = ttk.LabelFrame(lgeom, text="QBlade Simulation Input")
+        self.qblade_frame.grid(row=1, column=0, sticky="nsew", padx=(0, 6))
+        ttk.Label(self.qblade_frame, text="QBlade Simulation (.sim):").grid(row=0, column=0, sticky="w")
+        self.qblade_sim_path = PathEntry(
+            self.qblade_frame,
+            kind="file",
+            title="Select QBlade simulation (.sim)",
+            must_exist=True,
+            on_select=lambda _path: self.load_qblade_inputs(),
+            button_text="Load",
+        )
+        self.qblade_sim_path.grid(row=1, column=0, sticky="ew", pady=2)
+        ttk.Button(self.qblade_frame, text="Save VorLap CSVs", command=self.save_qblade_components).grid(row=1, column=1, padx=6)
+        ttk.Checkbutton(
+            self.qblade_frame,
+            text="Include Tower",
+            variable=self.include_qblade_tower,
+        ).grid(row=2, column=0, sticky="w", pady=(4, 0))
+        self.qblade_frame.columnconfigure(0, weight=1)
+
+        # Components section (right)
+        self.components_frame = ttk.LabelFrame(lgeom, text="Component Geometric Definition")
+        lcomp = self.components_frame
+        lcomp.grid(row=1, column=1, sticky="nsew", padx=(6, 0))
+        ttk.Label(lcomp, text="Components Directory").grid(row=0, column=0, sticky="w")
+        self.components_path = PathEntry(
+            lcomp,
+            kind="dir",
+            title="Select components directory",
+            must_exist=True,
+            on_select=lambda _path: self.load_components(),
+        )
+        self.components_path.grid(row=1, column=0, sticky="ew", pady=2)
+        ttk.Button(lcomp, text="Import", command=self.load_components).grid(row=1, column=1, padx=6)
+        ttk.Label(lcomp, text="Component Geometry List").grid(row=2, column=0, sticky="w", pady=(6, 0))
+        
+        # Component geometry table (read-only)
+        cols = [
+            "Component ID", "Translation X", "Translation Y", "Translation Z", 
+            "Rotation X", "Rotation Y", "Rotation Z", "Pitch", 
+            "Segments", "Avg Chord", "Avg Twist", "Avg Thickness", "Common Airfoil"
+        ]
+        self.geom_table = EditableTreeview(lcomp, columns=cols, height=8, non_editable_columns=cols)
+        self.geom_table.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(2, 0))
+        
+        # Add note about CSV editing
+        note_frame = ttk.Frame(lcomp)
+        note_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(5, 0))
+        note_label = ttk.Label(note_frame, 
+                              text="Note: Component geometry must be edited directly in the CSV files due to software limitations. " +
+                                   "Use the 'Import' or 'Load' button to refresh the table after making changes.",
+                              font=('Segoe UI', 9),
+                              foreground='#666666',
+                              wraplength=800)
+        note_label.pack(anchor="w")
+        
+        lcomp.columnconfigure(0, weight=1)
+        lcomp.rowconfigure(3, weight=0)  # Fixed weight for geometry table (non-collapsible)
+        lgeom.columnconfigure(0, weight=1)
+        lgeom.columnconfigure(1, weight=1)
+        row += 1
+
         # Time-varying inflow file (required for force time-history output)
-        linflow = ttk.LabelFrame(self, text="Time-Varying Inflow Profile")
+        linflow = ttk.LabelFrame(container, text="Time-Varying Inflow Profile")
         linflow.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
         ttk.Label(linflow, text="Profile CSV (required): time, inflow_speed, inflow_direction_deg").grid(
             row=0, column=0, sticky="w"
@@ -84,76 +178,6 @@ class SimulationSetupTab(ttk.Frame):
         self.inflow_profile_path.grid(row=1, column=0, sticky="ew", pady=2)
         linflow.columnconfigure(0, weight=1)
         row += 1
-
-        # QBlade fast-path import (optional)
-        lqblade = ttk.LabelFrame(self, text="QBlade Fast-Path (Optional)")
-        lqblade.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
-        ttk.Label(lqblade, text="QBlade Simulation (.sim):").grid(row=0, column=0, sticky="w")
-        self.qblade_sim_path = PathEntry(
-            lqblade,
-            kind="file",
-            title="Select QBlade simulation (.sim)",
-            must_exist=True,
-        )
-        self.qblade_sim_path.grid(row=1, column=0, sticky="ew", pady=2)
-        ttk.Button(lqblade, text="Import QBlade Model", command=self.load_qblade_inputs).grid(row=1, column=1, padx=6)
-
-        ttk.Label(lqblade, text="QBlade Loading Output (optional):").grid(row=2, column=0, sticky="w", pady=(6, 0))
-        self.qblade_loading_path = PathEntry(
-            lqblade,
-            kind="savefile",
-            title="Select QBlade loading output file",
-            must_exist=False,
-        )
-        self.qblade_loading_path.grid(row=3, column=0, sticky="ew", pady=2)
-        lqblade.columnconfigure(0, weight=1)
-        row += 1
-
-        # Simulation Parameters
-        lpars = ttk.LabelFrame(self, text="Simulation Parameters")
-        lpars.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
-        ttk.Label(lpars, text="File Path").grid(row=0, column=0, sticky="w")
-        self.param_path = PathEntry(lpars, kind="file", title="Select parameters CSV", must_exist=True)
-        self.param_path.grid(row=1, column=0, sticky="ew", pady=2)
-        ttk.Button(lpars, text="Import", command=self.import_params).grid(row=1, column=1, padx=6)
-        ttk.Label(lpars, text="Simulation Parameters List").grid(row=2, column=0, sticky="w", pady=(6, 0))
-        self.param_table = EditableTreeview(lpars, columns=["Description", "Parameter", "Value"], non_editable_columns=["Description"])
-        self.param_table.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(2, 0))
-        lpars.columnconfigure(0, weight=1)
-        lpars.rowconfigure(3, weight=0)  # Fixed weight for parameter table (non-collapsible)
-        row += 1
-
-        # Components section
-        lcomp = ttk.LabelFrame(self, text="Component Geometric Definition")
-        lcomp.grid(row=row, column=0, columnspan=6, sticky="ew", pady=(10, 6))
-        ttk.Label(lcomp, text="Components Directory").grid(row=0, column=0, sticky="w")
-        self.components_path = PathEntry(lcomp, kind="dir", title="Select components directory", must_exist=True)
-        self.components_path.grid(row=1, column=0, sticky="ew", pady=2)
-        ttk.Button(lcomp, text="Import", command=self.load_components).grid(row=1, column=1, padx=6)
-        ttk.Label(lcomp, text="Component Geometry List").grid(row=2, column=0, sticky="w", pady=(6, 0))
-        
-        # Component geometry table (read-only)
-        cols = [
-            "Component ID", "Translation X", "Translation Y", "Translation Z", 
-            "Rotation X", "Rotation Y", "Rotation Z", "Pitch", 
-            "Segments", "Avg Chord", "Avg Twist", "Avg Thickness"
-        ]
-        self.geom_table = EditableTreeview(lcomp, columns=cols, height=8, non_editable_columns=cols)
-        self.geom_table.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(2, 0))
-        
-        # Add note about CSV editing
-        note_frame = ttk.Frame(lcomp)
-        note_frame.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(5, 0))
-        note_label = ttk.Label(note_frame, 
-                              text="Note: Component geometry must be edited directly in the CSV files due to software limitations. " +
-                                   "Use the 'Import' button to refresh the table after making changes.",
-                              font=('Segoe UI', 9),
-                              foreground='#666666',
-                              wraplength=800)
-        note_label.pack(anchor="w")
-        
-        lcomp.columnconfigure(0, weight=1)
-        lcomp.rowconfigure(3, weight=0)  # Fixed weight for geometry table (non-collapsible)
         
         # Set default components path
         default_path = os.path.join(vorlap.repo_dir, "data", "components", "componentsHVAWT")
@@ -162,7 +186,7 @@ class SimulationSetupTab(ttk.Frame):
         
         # Set default save path (same directory as the script)
         default_save_path = vorlap.repo_dir
-        self.sim_save.set(default_save_path)
+        self.sim_save_var.set(default_save_path)
         
         # Default frequency file path
         default_freq_path = os.path.join(vorlap.repo_dir, "data", "natural_frequencies.csv")
@@ -183,16 +207,37 @@ class SimulationSetupTab(ttk.Frame):
 
         # Initialize with default parameters
         self._populate_default_params()
+        self.import_freq(show_dialog_on_error=False)
+        if not [w for w in self.freq_inner_frame.winfo_children() if isinstance(w, ttk.Entry)]:
+            self._populate_frequency_entries([0.07])
+            self.app.log("Loaded fallback default frequency: 0.07 Hz\n")
+        self._apply_geometry_source_state()
+
+        # Enforce requested visual order:
+        # 1) Geometry Input Source
+        # 2) Time-Varying Inflow Profile
+        # 3) Simulation Parameters
+        # 4) Parked Modal Frequencies
+        lgeom.grid_configure(row=0)
+        linflow.grid_configure(row=1)
+        lpars.grid_configure(row=2)
+        lfreq.grid_configure(row=3)
 
         # Make grid flexible
         for c in range(6):
-            self.columnconfigure(c, weight=(1 if c in (1, 3) else 0))
-        # Set parameter and component sections to have fixed weight (non-collapsible)
-        self.rowconfigure(2, weight=0, minsize=200)  # Frequency section with minimum size
-        self.rowconfigure(3, weight=0, minsize=80)   # Inflow profile section
-        self.rowconfigure(4, weight=0, minsize=120)  # QBlade section
-        self.rowconfigure(5, weight=0, minsize=200)  # Parameter section with minimum size
-        self.rowconfigure(6, weight=0, minsize=250)  # Component section with minimum size
+            container.columnconfigure(c, weight=(1 if c in (1, 3) else 0))
+        # Set section heights.
+        container.rowconfigure(0, weight=0, minsize=260)  # Geometry source section
+        container.rowconfigure(1, weight=0, minsize=90)   # Inflow profile section
+        container.rowconfigure(2, weight=0, minsize=200)  # Parameter section
+        container.rowconfigure(3, weight=0, minsize=200)  # Frequency section
+
+    def on_tab_selected(self):
+        try:
+            self.update_idletasks()
+            self.scrollable.refresh()
+        except Exception:
+            pass
 
     def _get_param_descriptions(self):
         """Get parameter descriptions mapping."""
@@ -258,6 +303,28 @@ class SimulationSetupTab(ttk.Frame):
         for param, value in default_params:
             description = descriptions.get(param, "")
             self.param_table.append_row([description, param, value])
+
+    def _set_widget_state_recursive(self, widget, enabled):
+        for child in widget.winfo_children():
+            self._set_widget_state_recursive(child, enabled)
+        try:
+            if hasattr(widget, "state"):
+                if enabled:
+                    widget.state(["!disabled"])
+                else:
+                    widget.state(["disabled"])
+            else:
+                widget.configure(state=("normal" if enabled else "disabled"))
+        except Exception:
+            pass
+
+    def _apply_geometry_source_state(self):
+        use_qblade = bool(self.use_qblade_geometry.get())
+        self._set_widget_state_recursive(self.qblade_frame, True)
+        self._set_widget_state_recursive(self.components_frame, not use_qblade)
+
+    def _on_qblade_toggle(self):
+        self._apply_geometry_source_state()
 
     def get_viv_params(self):
         """Create VIV_Params object from the current parameter table."""
@@ -332,20 +399,38 @@ class SimulationSetupTab(ttk.Frame):
     # ---- handlers ----
     def run_and_save(self):
         """Run the complete VorLap analysis."""
+        def ui_log(message: str):
+            self.app.after(0, self.app.log, message)
+
+        def ui_error(title: str, message: str):
+            self.app.after(0, lambda: messagebox.showerror(title, message))
+
+        def ui_populate_geometry_table(components):
+            self.app.after(0, lambda: self._populate_geometry_table(components))
+
+        def ui_update_plots():
+            self.app.after(0, self.app.tab_plots.update_plots)
+
         def run_analysis():
             try:
-                self.app.log("Starting VorLap analysis...\n")
-                self.app.log(f"  Save directory: {self.sim_save.get()}\n")
+                ui_log("Starting VorLap analysis...\n")
+                ui_log(f"  Save directory: {self.sim_save_var.get()}\n")
                 
                 # Get parameters
                 viv_params = self.get_viv_params()
                 qblade_node_ids = None
 
                 qblade_sim_path = self.qblade_sim_path.get().strip()
-                if qblade_sim_path:
-                    self.app.log(f"Converting QBlade model from: {qblade_sim_path}\n")
+                if self.use_qblade_geometry.get():
+                    if not qblade_sim_path:
+                        raise ValueError(
+                            "QBlade Geometry is enabled but no QBlade simulation file is set. "
+                            "Choose a `.sim` file or uncheck QBlade Geometry."
+                        )
+                    ui_log(f"Converting QBlade model from: {qblade_sim_path}\n")
                     components_from_qblade, qblade_viv_params, qblade_node_ids = vorlap.convert_qblade_to_vorlap_inputs(
-                        qblade_sim_path
+                        qblade_sim_path,
+                        include_tower=bool(self.include_qblade_tower.get()),
                     )
                     self.app.components = components_from_qblade
                     # Keep user sweep settings, but align key fluid/flow frame fields with QBlade.
@@ -354,10 +439,12 @@ class SimulationSetupTab(ttk.Frame):
                     viv_params.rotation_axis = qblade_viv_params.rotation_axis
                     viv_params.rotation_axis_offset = qblade_viv_params.rotation_axis_offset
                     viv_params.inflow_vec = qblade_viv_params.inflow_vec
-                    self._populate_geometry_table(self.app.components)
-                    self.app.log(
+                    ui_populate_geometry_table(self.app.components)
+                    ui_log(
                         f"Imported {len(self.app.components)} components and {len(qblade_node_ids)} QBlade load targets\n"
                     )
+                else:
+                    qblade_sim_path = ""
 
                 inflow_profile_path = self.inflow_profile_path.get().strip()
                 if not inflow_profile_path:
@@ -366,60 +453,75 @@ class SimulationSetupTab(ttk.Frame):
                         "Provide a file with: time, inflow_speed, inflow_direction_deg."
                     )
                 inflow_profile = vorlap.load_inflow_time_series(inflow_profile_path)
-                self.app.log(
+                ui_log(
                     f"Loaded inflow profile with {inflow_profile.time.size} samples: {inflow_profile_path}\n"
                 )
                 
                 # Get natural frequencies
                 natfreqs = self.get_natural_frequencies()
                 if natfreqs is None:
-                    self.app.log("Error: No natural frequencies loaded\n")
+                    ui_log("Error: No natural frequencies loaded\n")
                     return
                 
                 # Get components
                 components = self.app.components
                 if not components:
-                    self.app.log("Error: No components loaded\n")
+                    ui_log("Error: No components loaded\n")
                     return
                 
                 # Load airfoils
                 affts = self.app.load_airfoils(viv_params.airfoil_folder)
                 if not affts:
-                    self.app.log("Error: No airfoil data loaded\n")
+                    ui_log("Error: No airfoil data loaded\n")
                     return
                 
                 # assemble each component into a full structure, and we need the rotation axis
                 # plot the full structure surface with a generic airfoil shape
-                vorlap.graphics.calc_structure_vectors_andplot(components, viv_params)
+                vorlap.graphics.calc_structure_vectors_andplot(
+                    components,
+                    viv_params,
+                    show_plot=False,
+                    return_fig=False,
+                )
             
                 # Run computation
-                self.app.log("Running thrust/torque spectrum computation...\n")
+                ui_log("Running thrust/torque spectrum computation...\n")
                 start_time = time.time()
-                
-                # percdiff_matrix, percdiff_info, total_global_force_vector, total_global_moment_vector, global_force_vector_nodes = vorlap.compute_thrust_torque_spectrum(
-                #     components, affts, viv_params, natfreqs
-                # )
-                percdiff_matrix, percdiff_info, total_global_force_vector, total_global_moment_vector, global_force_vector_nodes = vorlap.compute_thrust_torque_spectrum_optimized(
-                    components, affts, viv_params, natfreqs
-                ) 
+                with warnings.catch_warnings(record=True) as captured_warnings:
+                    warnings.simplefilter("always")
 
-                self.app.log("Running time-varying force history reconstruction...\n")
-                (
-                    inflow_time,
-                    tv_total_global_force_vector,
-                    tv_total_global_moment_vector,
-                    tv_global_force_vector_nodes,
-                ) = vorlap.compute_time_varying_force_history_optimized(
-                    components=components,
-                    affts=affts,
-                    viv_params=viv_params,
-                    inflow_profile=inflow_profile,
-                    azimuth_deg=viv_params.output_azimuth_vinf[0],
-                    smoothing_cycles=0.25,
-                )
+                    # percdiff_matrix, percdiff_info, total_global_force_vector, total_global_moment_vector, global_force_vector_nodes = vorlap.compute_thrust_torque_spectrum(
+                    #     components, affts, viv_params, natfreqs
+                    # )
+                    percdiff_matrix, percdiff_info, total_global_force_vector, total_global_moment_vector, global_force_vector_nodes = vorlap.compute_thrust_torque_spectrum_optimized(
+                        components, affts, viv_params, natfreqs
+                    ) 
+
+                    ui_log("Running time-varying force history reconstruction...\n")
+                    (
+                        inflow_time,
+                        tv_total_global_force_vector,
+                        tv_total_global_moment_vector,
+                        tv_global_force_vector_nodes,
+                    ) = vorlap.compute_time_varying_force_history_optimized(
+                        components=components,
+                        affts=affts,
+                        viv_params=viv_params,
+                        inflow_profile=inflow_profile,
+                        azimuth_deg=viv_params.output_azimuth_vinf[0],
+                        smoothing_cycles=0.25,
+                    )
+
+                seen_warning_messages = set()
+                for warning_record in captured_warnings:
+                    warning_message = str(warning_record.message).strip()
+                    if not warning_message or warning_message in seen_warning_messages:
+                        continue
+                    seen_warning_messages.add(warning_message)
+                    ui_log(f"Warning: {warning_message}\n")
                 end_time = time.time()
                 execution_time = end_time - start_time
-                self.app.log(f"Computation completed in {execution_time:.4f} seconds\n")
+                ui_log(f"Computation completed in {execution_time:.4f} seconds\n")
                 
                 # Store results in app
                 self.app.analysis_results = {
@@ -438,9 +540,9 @@ class SimulationSetupTab(ttk.Frame):
                 }
                 
                 # Save force time series if save path is provided
-                if self.sim_save.get():
+                if self.sim_save_var.get():
                     from pathlib import Path
-                    save_dir = Path(self.sim_save.get())
+                    save_dir = Path(self.sim_save_var.get())
                     save_dir.mkdir(parents=True, exist_ok=True)
                     
                     force_file = save_dir / "forces_output.csv"
@@ -449,10 +551,10 @@ class SimulationSetupTab(ttk.Frame):
                         inflow_time,
                         tv_global_force_vector_nodes,
                     )
-                    self.app.log(f"Force time series saved to: {force_file}\n")
+                    ui_log(f"Force time series saved to: {force_file}\n")
 
                     if qblade_node_ids:
-                        qblade_loading_target = self.qblade_loading_path.get().strip()
+                        qblade_loading_target = self.qblade_loading_path_var.get().strip()
                         if qblade_loading_target:
                             qblade_loading_file = Path(qblade_loading_target)
                             if not qblade_loading_file.is_absolute():
@@ -467,23 +569,47 @@ class SimulationSetupTab(ttk.Frame):
                             qblade_node_ids,
                             local=False,
                         )
-                        self.app.log(f"QBlade loading file saved to: {qblade_loading_file}\n")
+                        ui_log(f"QBlade loading file saved to: {qblade_loading_file}\n")
                 
                 # Update plots
-                self.app.tab_plots.update_plots()
-                self.app.log("Analysis completed successfully!\n\n")
+                ui_update_plots()
+                ui_log("Analysis completed successfully!\n\n")
                 
             except Exception as e:
-                self.app.log(f"Error during analysis: {str(e)}\n")
-                messagebox.showerror("Analysis Error", str(e))
+                ui_log(f"Error during analysis: {str(e)}\n")
+                ui_error("Analysis Error", str(e))
 
         # Run analysis in separate thread to avoid GUI freezing
         threading.Thread(target=run_analysis, daemon=True).start()
 
-    def import_freq(self):
+    def _populate_frequency_entries(self, frequencies):
+        for widget in self.freq_inner_frame.winfo_children():
+            widget.destroy()
+
+        for i, freq_val in enumerate(frequencies):
+            entry = ttk.Entry(self.freq_inner_frame, width=8, justify="center")
+            entry.insert(0, f"{float(freq_val):.2f}")
+            entry.grid(row=0, column=i, padx=2)
+
+            def validate_freq(val):
+                try:
+                    if val == "":
+                        return True
+                    float(val)
+                    return True
+                except ValueError:
+                    return False
+
+            entry.configure(validate="key", validatecommand=(entry.register(validate_freq), "%P"))
+
+        self.freq_inner_frame.update_idletasks()
+        self.freq_canvas.configure(scrollregion=self.freq_canvas.bbox("all"))
+
+    def import_freq(self, show_dialog_on_error=True):
         path = self.freq_path.get()
         if not path:
-            messagebox.showwarning("No file", "Choose a CSV file.")
+            if show_dialog_on_error:
+                messagebox.showwarning("No file", "Choose a CSV file.")
             return
         try:
             # Load CSV and get the first row (assuming single-row file)
@@ -495,42 +621,23 @@ class SimulationSetupTab(ttk.Frame):
                     messagebox.showwarning("Empty file", "CSV file is empty.")
                     return
                 
-                # Clear previous frequencies
-                for widget in self.freq_inner_frame.winfo_children():
-                    widget.destroy()
-                
-                # Create entry widgets for each frequency value
-                for i, val in enumerate(row):
+                freq_values = []
+                for val in row:
                     try:
-                        freq_val = float(val.strip())
-                        entry = ttk.Entry(self.freq_inner_frame, width=8, justify="center")
-                        entry.insert(0, f"{freq_val:.2f}")
-                        entry.grid(row=0, column=i, padx=2)
-                        
-                        # Add validation to ensure only numeric values
-                        def validate_freq(val, entry_widget=entry):
-                            try:
-                                if val == "":
-                                    return True
-                                float(val)
-                                return True
-                            except ValueError:
-                                return False
-                        
-                        # Bind validation
-                        entry.configure(validate="key", validatecommand=(entry.register(validate_freq), "%P"))
+                        freq_values.append(float(val.strip()))
                     except ValueError:
                         # Skip non-numeric values
                         continue
+                self._populate_frequency_entries(freq_values)
                 
-                # Update canvas scroll region
-                self.freq_inner_frame.update_idletasks()
-                self.freq_canvas.configure(scrollregion=self.freq_canvas.bbox("all"))
-                
-                self.app.log(f"Loaded {len([w for w in self.freq_inner_frame.winfo_children()])} frequencies: {path}\n")
+                count = len([w for w in self.freq_inner_frame.winfo_children() if isinstance(w, ttk.Entry)])
+                self.app.log(f"Loaded {count} frequencies: {path}\n")
                 
         except Exception as e:
-            messagebox.showerror("Import failed", str(e))
+            if show_dialog_on_error:
+                messagebox.showerror("Import failed", str(e))
+            else:
+                self.app.log(f"Frequency default load failed: {str(e)}\n")
 
     def import_params(self):
         path = self.param_path.get()
@@ -574,6 +681,9 @@ class SimulationSetupTab(ttk.Frame):
             avg_thickness = np.mean(comp.thickness) if len(comp.thickness) > 0 else 0
             pitch_val = comp.pitch[0] if len(comp.pitch) > 0 else 0
             num_segments = len(comp.shape_xyz)
+            most_common_airfoil = ""
+            if len(comp.airfoil_ids) > 0:
+                most_common_airfoil = Counter(comp.airfoil_ids).most_common(1)[0][0]
 
             row = [
                 str(comp.id),
@@ -587,9 +697,28 @@ class SimulationSetupTab(ttk.Frame):
                 str(num_segments),
                 f"{avg_chord:.3f}",
                 f"{avg_twist:.2f}",
-                f"{avg_thickness:.3f}"
+                f"{avg_thickness:.3f}",
+                str(most_common_airfoil),
             ]
             self.geom_table.append_row(row)
+
+    def _queue_geometry_plot_refresh(self):
+        """Pre-populate the geometry plot after loading geometry inputs."""
+        if not self.app.components:
+            return
+
+        def _refresh():
+            try:
+                tab_plots = getattr(self.app, "tab_plots", None)
+                if tab_plots is None:
+                    return
+                tab_plots.plot_type.set("geometry")
+                tab_plots._update_geometry_controls()
+                tab_plots.update_plots(show_errors=False)
+            except Exception as exc:
+                self.app.log(f"Geometry plot pre-population failed: {exc}\n")
+
+        self.app.after_idle(_refresh)
 
     def load_qblade_inputs(self):
         """Load VorLap-equivalent components from a QBlade .sim file."""
@@ -599,23 +728,53 @@ class SimulationSetupTab(ttk.Frame):
             return
 
         try:
-            components, qblade_viv_params, qblade_node_ids = vorlap.convert_qblade_to_vorlap_inputs(qblade_sim)
+            components, qblade_viv_params, qblade_node_ids = vorlap.convert_qblade_to_vorlap_inputs(
+                qblade_sim,
+                include_tower=bool(self.include_qblade_tower.get()),
+            )
             self.app.components = components
             self._populate_geometry_table(components)
+            self._queue_geometry_plot_refresh()
             self.app.log(
                 f"Imported QBlade model: {qblade_sim}\n"
                 f"  Components: {len(components)}\n"
                 f"  QBlade load targets: {len(qblade_node_ids)}\n"
+                f"  Include tower: {bool(self.include_qblade_tower.get())}\n"
                 f"  Fluid density: {qblade_viv_params.fluid_density:.6g}\n"
                 f"  Dynamic viscosity: {qblade_viv_params.fluid_dynamicviscosity:.6g}\n"
             )
 
-            if not self.qblade_loading_path.get().strip():
-                default_loading = os.path.join(self.sim_save.get() or os.path.dirname(qblade_sim), "qblade_external_loading.txt")
-                self.qblade_loading_path.set(default_loading)
+            if not self.qblade_loading_path_var.get().strip():
+                default_loading = os.path.join(
+                    self.sim_save_var.get() or os.path.dirname(qblade_sim),
+                    "qblade_external_loading.txt",
+                )
+                self.qblade_loading_path_var.set(default_loading)
         except Exception as e:
             messagebox.showerror("Load failed", str(e))
             self.app.log(f"Error loading QBlade model: {str(e)}\n")
+
+    def save_qblade_components(self):
+        """Save the currently loaded components to VorLap component CSV files."""
+        if not self.app.components:
+            qblade_sim = self.qblade_sim_path.get().strip()
+            if qblade_sim:
+                self.load_qblade_inputs()
+
+        if not self.app.components:
+            messagebox.showwarning("No geometry", "Load a QBlade model first.")
+            return
+
+        out_dir = filedialog.askdirectory(title="Select output directory for VorLap components")
+        if not out_dir:
+            return
+
+        try:
+            written_files = vorlap.write_components_to_csv(out_dir, self.app.components)
+            self.app.log(f"Saved {len(written_files)} VorLap component files to: {out_dir}\n")
+        except Exception as e:
+            messagebox.showerror("Save failed", str(e))
+            self.app.log(f"Error saving components: {str(e)}\n")
 
     def load_components(self):
         """Load components from the selected directory."""
@@ -632,6 +791,7 @@ class SimulationSetupTab(ttk.Frame):
             # Update geometry table with component-level information
             if components:
                 self._populate_geometry_table(components)
+                self._queue_geometry_plot_refresh()
                     
         except Exception as e:
             messagebox.showerror("Load failed", str(e))

--- a/vorlap/gui/widgets.py
+++ b/vorlap/gui/widgets.py
@@ -11,17 +11,134 @@ from pathlib import Path
 import csv
 
 
+def _get_theme_colors(widget):
+    root = widget.winfo_toplevel()
+    return getattr(
+        root,
+        "_vorlap_theme_colors",
+        {
+            "entry_bg": "#ffffff",
+            "fg": "#2d3748",
+            "select_bg": "#4299e1",
+            "select_fg": "#ffffff",
+            "border": "#94a3b8",
+            "text_bg": "#ffffff",
+        },
+    )
+
+
+class ScrollableFrame(ttk.Frame):
+    """A vertically scrollable frame with mouse-wheel support."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, **kwargs)
+        self.canvas = tk.Canvas(self, highlightthickness=0, borderwidth=0)
+        self.vsb = ttk.Scrollbar(self, orient="vertical", command=self.canvas.yview)
+        self.canvas.configure(yscrollcommand=self.vsb.set)
+
+        self.content = ttk.Frame(self.canvas)
+        self._window_id = self.canvas.create_window((0, 0), window=self.content, anchor="nw")
+
+        self.canvas.grid(row=0, column=0, sticky="nsew")
+        self.vsb.grid(row=0, column=1, sticky="ns")
+
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
+
+        self.content.bind("<Configure>", self._on_content_configure)
+        self.canvas.bind("<Configure>", self._on_canvas_configure)
+        self.canvas.bind("<Expose>", self._on_expose, add="+")
+        self.bind("<Map>", self._on_map, add="+")
+
+        self.bind_all("<MouseWheel>", self._on_mousewheel, add="+")
+        self.bind_all("<Button-4>", self._on_mousewheel_linux_up, add="+")
+        self.bind_all("<Button-5>", self._on_mousewheel_linux_down, add="+")
+        self.winfo_toplevel().bind("<<VorLapThemeChanged>>", self._on_theme_changed, add="+")
+        self._on_theme_changed()
+
+    def _on_theme_changed(self, _event=None):
+        colors = _get_theme_colors(self)
+        self.canvas.configure(bg=colors.get("bg", colors.get("text_bg", "#ffffff")))
+
+    def _on_content_configure(self, _event=None):
+        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+
+    def _on_canvas_configure(self, event):
+        self.canvas.itemconfigure(self._window_id, width=event.width)
+        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+
+    def _on_expose(self, _event=None):
+        self.after_idle(self.refresh)
+
+    def _on_map(self, _event=None):
+        self.after_idle(self.refresh)
+
+    def refresh(self):
+        try:
+            self.update_idletasks()
+            width = max(1, self.canvas.winfo_width())
+            self.canvas.itemconfigure(self._window_id, width=width)
+            self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+            self.canvas.update_idletasks()
+        except Exception:
+            pass
+
+    def _is_inside(self, widget):
+        w = widget
+        while w is not None:
+            if w == self:
+                return True
+            w = w.master
+        return False
+
+    def _scroll(self, units):
+        self.canvas.yview_scroll(units, "units")
+
+    def _on_mousewheel(self, event):
+        widget = self.winfo_containing(event.x_root, event.y_root)
+        if widget is None or not self._is_inside(widget):
+            return
+        delta = event.delta
+        if delta == 0:
+            return
+        self._scroll(-1 if delta > 0 else 1)
+
+    def _on_mousewheel_linux_up(self, event):
+        widget = self.winfo_containing(event.x_root, event.y_root)
+        if widget is None or not self._is_inside(widget):
+            return
+        self._scroll(-1)
+
+    def _on_mousewheel_linux_down(self, event):
+        widget = self.winfo_containing(event.x_root, event.y_root)
+        if widget is None or not self._is_inside(widget):
+            return
+        self._scroll(1)
+
+
 class PathEntry(ttk.Frame):
     """Entry + Browse button (file or directory)."""
-    def __init__(self, master, kind="file", title="Select...", must_exist=False, **kwargs):
+    def __init__(
+        self,
+        master,
+        kind="file",
+        title="Select...",
+        must_exist=False,
+        on_select=None,
+        textvariable=None,
+        button_text="Browse",
+        **kwargs,
+    ):
         super().__init__(master, **kwargs)
         self.kind = kind          # "file" | "dir" | "savefile"
         self.title = title
         self.must_exist = must_exist
-        self.var = tk.StringVar()
+        self.on_select = on_select
+        self.button_text = str(button_text) if button_text else "Browse"
+        self.var = textvariable if textvariable is not None else tk.StringVar()
         self.entry = ttk.Entry(self, textvariable=self.var)
         self.entry.grid(row=0, column=0, sticky="ew", padx=(0, 4))
-        self.btn = ttk.Button(self, text="Browse", command=self.browse)
+        self.btn = ttk.Button(self, text=self.button_text, command=self.browse)
         self.btn.grid(row=0, column=1)
         self.columnconfigure(0, weight=1)
 
@@ -37,6 +154,8 @@ class PathEntry(ttk.Frame):
                 messagebox.showerror("Path not found", f"{path}\n\ndoes not exist.")
                 return
             self.var.set(path)
+            if callable(self.on_select):
+                self.on_select(path)
 
     def get(self) -> str:
         return self.var.get()
@@ -49,13 +168,14 @@ class ScrollText(ttk.Frame):
     """A Text widget with a vertical scrollbar."""
     def __init__(self, master, height=10, **kwargs):
         super().__init__(master, **kwargs)
+        colors = _get_theme_colors(self)
         self.text = tk.Text(self, wrap="word", height=height,
                            font=('Segoe UI', 10),
-                           bg='#ffffff',
-                           fg='#2d3748',
-                           selectbackground='#4299e1',
-                           selectforeground='#ffffff',
-                           insertbackground='#2d3748',
+                           bg=colors["text_bg"],
+                           fg=colors["fg"],
+                           selectbackground=colors["select_bg"],
+                           selectforeground=colors["select_fg"],
+                           insertbackground=colors["fg"],
                            borderwidth=1,
                            relief='solid',
                            padx=8,
@@ -66,6 +186,17 @@ class ScrollText(ttk.Frame):
         sb.grid(row=0, column=1, sticky="ns")
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
+        self.winfo_toplevel().bind("<<VorLapThemeChanged>>", self._on_theme_changed, add="+")
+
+    def _on_theme_changed(self, _event=None):
+        colors = _get_theme_colors(self)
+        self.text.configure(
+            bg=colors["text_bg"],
+            fg=colors["fg"],
+            selectbackground=colors["select_bg"],
+            selectforeground=colors["select_fg"],
+            insertbackground=colors["fg"],
+        )
 
     def write(self, s: str):
         self.text.insert("end", s)
@@ -154,13 +285,14 @@ class EditableTreeview(ttk.Frame):
         x, y, w, h = bbox
         value = self.tree.set(row_id, self.columns[col])
 
+        colors = _get_theme_colors(self)
         self._editor = tk.Entry(self.tree,
                                font=('Segoe UI', 10),
-                               bg='#ffffff',
-                               fg='#2d3748',
-                               selectbackground='#4299e1',
-                               selectforeground='#ffffff',
-                               insertbackground='#2d3748',
+                               bg=colors["entry_bg"],
+                               fg=colors["fg"],
+                               selectbackground=colors["select_bg"],
+                               selectforeground=colors["select_fg"],
+                               insertbackground=colors["fg"],
                                borderwidth=1,
                                relief='solid')
         self._editor.insert(0, value)

--- a/vorlap/structs.py
+++ b/vorlap/structs.py
@@ -33,8 +33,7 @@ class AirfoilFFT:
         CD_Pha (np.ndarray): FFT phases of CD
         CM_Pha (np.ndarray): FFT phases of CM
         CF_Pha (np.ndarray): FFT phases of CF
-        
-        # Cached interpolators for performance optimization
+
         _interpolators_cached (bool): Whether interpolators are pre-computed
         _cl_st_interps (List): Pre-computed ST interpolators for CL
         _cl_amp_interps (List): Pre-computed amplitude interpolators for CL


### PR DESCRIPTION
- Keep QBlade inputs enabled; only disable VorLap directory input when QBlade Geometry is on
- Add QBlade “Load” + “Save VorLap CSVs” geometry workflow
- Add “Common Airfoil” column to geometry summary table
- Default imported tower airfoil to cylinder
- Surface missing-airfoil fallback warnings in GUI console output
- Pre-populate geometry plot on geometry load and simplify plot save UI
- Add tests for component export roundtrip, tower default airfoil, and airfoil fallback warning
- Update README GUI launch note (python3 / shell alias issue)